### PR TITLE
Equalizing release-7.0.2 to develop

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,9 @@ machine:
     sc.circle: 127.0.0.1
     api.sc.circle: 127.0.0.1
 
+  environment:
+    SAUCE_TUNNEL_ID: circle-$CIRCLE_BUILD_NUM
+
 dependencies:
   pre:
 
@@ -63,9 +66,6 @@ test:
 
 general:
   branches:
-    only:
-      # only build develop, master and release branches
-      - develop
-      - master
-      - /release-.*/
-      - 91354686_oe_person
+    ignore:
+      # add your branch name here if you don't want it to build in CircleCI
+      - do_not_build_this_branch


### PR DESCRIPTION
Some updates for this release were committed directly into develop. They must be pulled into the release branch.